### PR TITLE
qwery: Remove misleading perf quote from readme, as speed isn't 2x faster

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Q('wery') - The Tiny Selector Engine
 -----
-Qwery is a 1k *blazing fast* query selector engine allowing you to select elements with CSS1 & CSS2 selectors (including [attribute selectors](http://www.w3.org/TR/css3-selectors/#attribute-selectors)). And according to our benchmarks Qwery is 2x faster (at minimum on average) than Sizzle (from jQuery).
+Qwery is a 1k *blazing fast* query selector engine allowing you to select elements with CSS1 & CSS2 selectors (including [attribute selectors](http://www.w3.org/TR/css3-selectors/#attribute-selectors)).
 
 Acceptable queries
 ---------------


### PR DESCRIPTION
qwery: Remove misleading perf quote from readme, as speed isn't 2x faster see: [http://jsperf.com/qwery-vs-sizzle](http://jsperf.com/qwery-vs-sizzle#comment-3). [jddalton]
