### PR TITLE
qwery: Simplify regexp in clean() and escape more special characters. [jd

### DIFF
--- a/qwery.js
+++ b/qwery.js
@@ -98,7 +98,7 @@
   }
 
   function clean(s) {
-    return cleanCache.g(s) || cleanCache.s(s, s.replace(/([\.\*\+\?\^\$\{\}\(\)\|\[\]\/\\])/g, '\\$1'));
+    return cleanCache.g(s) || cleanCache.s(s, s.replace(/([.*+?^=!:${}()|[\]\/\\])/g, '\\$1'));
   }
 
   function checkAttr(qualify, actual, val) {


### PR DESCRIPTION
qwery: Simplify regexp in clean() and escape more special characters. [jddalton]
