### PR TITLE
Make qwery compatible with ender.noConflict()

### DIFF
--- a/src/ender.js
+++ b/src/ender.js
@@ -1,4 +1,4 @@
-!function (doc) {
+!function (doc, $) {
   var q = qwery.noConflict();
   var table = 'table',
       nodeMap = {
@@ -46,4 +46,4 @@
       return this;
     }
   }, true);
-}(document);
+}(document, ender || $);


### PR DESCRIPTION
Hey guys, first off thanks a ton for ender and your awesome micro-libraries. They are fantastic, and I appreciate the work you've put in. I've learned a lot just by reading over the code.

Now on to the problem :) -- it seems that Qwery is not compatible with Ender's <code>noConflict()</code>. As it is now, the <code>find()</code> & <code>and()</code> methods reference a global '$' variable that doesn't exist after using noConflict (or setting it to something else after ender is loaded).

I believe this patch should fix that. I basically did the same thing that bonzo does in its ender bridge, and added a '$' variable to the main closure function in ender.js, and then passed it a reference to ender.

It seems to work, but I only tested it by "hacking" my current Ender build, rather than building a new version with my forked Qwery (which I'm not sure how to do). Dunno if that matters or not.

Let me know if that makes sense and if it's the right solution. Or if I'm crazy and totally off-base ;)

Thanks!
