### PR TITLE
Sibling combinators are broken

### DIFF
--- a/tests/index.html
+++ b/tests/index.html
@@ -92,6 +92,14 @@
       <div id="sibling-selector"></div>
       <div class="sibling-selector"></div>
       <div class="sibling-selector"></div>
+      
+      <div class="parent">
+        <h1 class="sibling oldest"></h1>
+        <h2 class="sibling older"></h2>
+        <h3 class="sibling middle"></h3>
+        <h4 class="sibling younger"></h4>
+        <h5 class="sibling youngest"></h5>
+      </div>
     </div>
      <ol id="tests"></ol>
      <script src="tests.js"></script>

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -127,11 +127,26 @@ sink('attribute selectors', function (test, ok) {
     ok(Q('#direct-descend > .direct-descend').length == 2, 'found two direct descendents');
   });
 
-  test('sibling elements', 4, function () {
+  test('sibling elements', 17, function () {
     ok(Q('#sibling-selector ~ .sibling-selector').length == 2, 'found two siblings')
     ok(Q('#sibling-selector ~ div.sibling-selector').length == 2, 'found two siblings')
     ok(Q('#sibling-selector + div.sibling-selector').length == 1, 'found two siblings')
     ok(Q('#sibling-selector + .sibling-selector').length == 1, 'found two siblings')
+
+    ok(Q('.parent .oldest ~ .sibling').length == 4, 'found four younger siblings')
+    ok(Q('.parent .middle ~ .sibling').length == 2, 'found two younger siblings')
+    ok(Q('.parent .middle ~ h4').length == 1, 'found next sibling by tag')
+    ok(Q('.parent .middle ~ h4.younger').length == 1, 'found next sibling by tag and class')
+    ok(Q('.parent .middle ~ h3').length == 0, 'an element can\'t be its own sibling')
+    ok(Q('.parent .middle ~ h2').length == 0, 'didn\'t find an older sibling')
+    ok(Q('.parent .youngest ~ .sibling').length == 0, 'found no younger siblings')
+
+    ok(Q('.parent .oldest + .sibling').length == 1, 'found next sibling')
+    ok(Q('.parent .middle + .sibling').length == 1, 'found next sibling')
+    ok(Q('.parent .middle + h4').length == 1, 'found next sibling by tag')
+    ok(Q('.parent .middle + h3').length == 0, 'an element can\'t be its own sibling')
+    ok(Q('.parent .middle + h2').length == 0, 'didn\'t find an older sibling')
+    ok(Q('.parent .youngest + .sibling').length == 0, 'found no younger siblings')
   });
 
 });


### PR DESCRIPTION
I added some test cases that expose the issue. These tests will pass in a browser that has a good qSA implementation (Chrome), but will fail when Qwery runs them, like if you add this above the qwery script tag in tests/index.html:

```
<!-- Override doc.qSA -->
<script type="text/javascript" charset="utf-8">
  document.querySelectorAll = null;
</script>
```
