### PR TITLE
IE tests

### DIFF
--- a/src/qwery.js
+++ b/src/qwery.js
@@ -277,6 +277,10 @@
       selector = selector.replace(normalizr, '$1')
       var result = [], element, collection, collections = [], i
       if (m = selector.match(tagAndOrClass)) {
+        // simple & common case, safe to use non-CSS3 qSA if present
+        if (root.querySelectorAll) {
+          return flatten(root.querySelectorAll(selector))
+        }
         items = root.getElementsByTagName(m[1] || '*');
         r = classCache.g(m[2]) || classCache.s(m[2], new RegExp('(^|\\s+)' + m[2] + '(\\s+|$)'));
         for (i = 0, l = items.length, j = 0; i < l; i++) {


### PR DESCRIPTION
2 changes:

1) latest pull request screwed up IE support even more by double using the global `i` so I've simply redefined it locally where it's causing the problem.
2) I finally got my head around it and figured out why the IE<9 tests weren't all passing: the context-node collection wasn't working because if you don't have an ID selector anywhere in your query then you default to `document` which you can't collect siblings of and you really have to do a brute-force through `getElementsByTagName('*')`.

Now all tests are passing in IE6+ et. al.
