### PR TITLE
Fix massively inefficient CSS3 detection selector.

### DIFF
--- a/qwery.js
+++ b/qwery.js
@@ -310,7 +310,7 @@
   , supportsCSS3 = function () {
       // does native qSA support CSS3 level selectors
       try {
-        return doc[byClass] && doc.querySelector && doc[qSA] && doc[qSA](':nth-of-type(1)').length
+        return doc[byClass] && doc.querySelector && doc[qSA] && doc[qSA]('body:nth-of-type(1)').length
       } catch (e) { return false }
     }()
   , select = supportsCSS3 ?


### PR DESCRIPTION
- Calling :nth-of-type(1) alone takes about 2 seconds in IE.
- Qualifying it with body: reduces it to milliseconds.

Hat-tip: Mark Christian.
