### PR TITLE
byId fixes and feature additions

### DIFF
--- a/src/qwery.js
+++ b/src/qwery.js
@@ -104,6 +104,7 @@
   // div.hello[title="world"]:foo('bar'), div, .hello, [title="world"], title, =, world, :foo('bar'), foo, ('bar'), bar]
   function interpret(whole, tag, idsAndClasses, wholeAttribute, attribute, qualifier, value, wholePseudo, pseudo, wholePseudoVal, pseudoVal) {
     var i, m, k, o, classes
+    if (this.nodeType !== 1) return false
     if (tag && tag !== '*' && this.tagName && this.tagName.toLowerCase() !== tag) return false
     if (idsAndClasses && (m = idsAndClasses.match(id)) && m[1] !== this.id) return false
     if (idsAndClasses && (classes = idsAndClasses.match(clas))) {

--- a/tests/index.html
+++ b/tests/index.html
@@ -52,11 +52,15 @@
       <div class="a"></div>
       <div class="class-with-dashes"></div>
       <div id="boosh">
+        <!-- comment -->
+        <!-- comment -->
         <div class="a b">
           <div class="d e" test="fg" id="booshTest"></div>
+          <!-- comment -->
           <em nopass="copyrighters" rel="copyright booshrs" test="f g"></em>
           <span class="h i a"></span>
         </div>
+        <!-- comment -->
       </div>
       <div id="lonelyBoosh"></div>
       <div id="attr-test1" -data-attr></div>

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -75,6 +75,10 @@ sink('CSS 1', function (test, ok) {
     ok(Q('.class-with-dashes').length == 1, 'found something');
   });
 
+  test('should ignore comment nodes', 1, function() {
+    ok(Q('#boosh *').length === 4, 'found only 4 elements under #boosh')
+  });
+
   test('deep messy relationships', 6, function() {
     // these are mostly characterised by a combination of tight relationships and loose relationships
     // on the right side of the query it's easy to find matches but they tighten up quickly as you
@@ -266,7 +270,7 @@ sink('attribute selectors', function (test, ok, b, a, assert) {
 
 });
 
-sink('Element-context queries', function(test, ok) {
+sink('element-context queries', function(test, ok) {
   test('relationship-first queries', 5, function() {
     var pass = false
     try { pass = Q('> .direct-descend', Q('#direct-descend')).length == 2 } catch (e) { }
@@ -492,7 +496,7 @@ sink('argument types', function (test, ok) {
 
 });
 
-sink('testing is()', function (test, ok) {
+sink('is()', function (test, ok) {
   var el = document.getElementById('attr-child-boosh');
   test('simple selectors', 9, function () {
     ok(Q.is(el, 'li'), 'tag');


### PR DESCRIPTION
byId only called on document nodes, either just `document` or `ownerDocument` of the context element. isAncestor check is performed so you can narrow the query down.

Lots of tests to demonstrate the fixes newly supported features.

Should allow #60 and #36 to be closed.

/cc @mkristo @OrTure @techosaurus
