### PR TITLE
Added missing 'main' property to components.json. Required for it to work.

### DIFF
--- a/component.json
+++ b/component.json
@@ -7,6 +7,7 @@
   "dependencies": {},
   "development": {},
   "license": "MIT",
+  "main": "qwery.js",
   "scripts": [
     "qwery.js"
   ]


### PR DESCRIPTION
@ded My apologies. I left this out. It's required whenever the main file name isn't the default 'index.js'.

Love the library btw.
Super slick.
